### PR TITLE
chore: bump Go to 1.26.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tender-barbarian/go-llm-lens
 
-go 1.25.7
+go 1.26.4
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION
## Summary

Bumps the Go toolchain from `1.25.7` to `1.26.4`