### PR TITLE
ci: stop running CI twice on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
 
 permissions: read-all

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: CodeQL
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
   schedule:
     - cron: "30 2 * * 1"  # every Monday at 02:30 UTC


### PR DESCRIPTION
## Summary

CI (and CodeQL) ran twice for every pull request. Both workflows triggered on `push: branches: ["**"]` *and* `pull_request` — so pushing a branch that has an open PR fired both events, doubling every run.

This restricts the `push` trigger to `main`:

```yaml
on:
  push:
    branches: [main]
  pull_request:
```

- **Push to `main`** (post-merge) → runs once via the push event
- **PR branches** → run once via the `pull_request` event
- No more duplicate runs

Applied to both `ci.yml` and `codeql.yml` (CodeQL keeps its weekly `schedule` trigger). `release.yml` is tag-triggered and unaffected.